### PR TITLE
Make sure to install mocha for running tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function(grunt) {
     shell: {
       jshint: {command: 'node_modules/.bin/jshint ' + JS_FILES.join(' ')},
       mocha: {
-        command: 'mocha --recursive --compilers js:babel-core/register ' +
+        command: 'node_modules/.bin/mocha --recursive ' +
+          '--compilers js:babel-core/register ' +
           '--require ./test/setup.js'
       },
       npmPublish: {command: 'npm publish'},

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jsdom": "^7.2.1",
     "jshint": "^2.9.1-rc1",
     "load-grunt-tasks": "^3.3.0",
+    "mocha": "^2.3.4",
     "riot": "^2.3.12",
     "semver": "^5.1.0",
     "webpack": "^1.12.9",


### PR DESCRIPTION
Mocha wasn't included as a development dependency, so it wasn't installed when doing a `npm install`.

Also, the Gruntfile uses the global reference to mocha, so the test task doesn't run unless you install mocha globally. I modified the Gruntfile to use a local reference to mocha, as installed in `node_modules`.
