### PR TITLE
A not invading namespace way, for reference only

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,22 @@ tiger.tag
   </script>
 </tiger>
 ```
+
+also supports use store inside tag
+
+tiger.tag
+```html
+<tiger>
+  <p>{age}</p> <!-- 12 -->
+  <button onclick={roar}></button> <!-- Clicking me prints 'BWAAA!' in the console. -->
+  <script>
+    const store = configureStore({age:12});
+    let actions = {roar: () => console.log('BWAAA!')};
+    let selector = (state) => ({age: state.age});
+    let riotRedux = require("riot-redux").default
+    this.mixin(riotRedux(
+      store, selector, actions
+    ));
+  </script>
+</tiger>
+```

--- a/index.js
+++ b/index.js
@@ -1,52 +1,30 @@
+// migrate from https://github.com/danny-andrews/riot-redux
+
 import { bindActionCreators } from 'redux';
 
 function assert(thingToBeTruthy, message) {
   if(!thingToBeTruthy) { throw new Error(message); }
 }
-
-export default function(store) {
+let defaultSelector = (state)=> state
+export default function(store, selector, actions) {
   assert(store, '"store" cannot be null!');
 
-  function subscribe(selector) {
-    let callback = (state) => this.update(state);
-    let currentState = selector(store.getState());
-
-    function handleChange() {
-      let nextState = selector(store.getState());
-      if(nextState !== currentState) {
-        currentState = nextState;
-        callback(currentState);
+  function init() {
+    selector = selector || this.opts.selector || defaultSelector;
+    actions = actions || this.opts.actions;
+    if(actions)this.actions = bindActionCreators(actions, store.dispatch);
+    let getState = ()=> selector(store.getState())
+    let subscribe = ()=>{
+      let nextState = getState();
+      if(nextState !== this.state) {
+        this.state = nextState;
+        this.update();
       }
     }
-
-    let unsubscribe = store.subscribe(handleChange);
-    handleChange();
-    return unsubscribe;
-  }
-
-  function init() {
-    let {actions: actions = {}, selector: selector = () => ({})} = this.opts;
-    let boundActions = bindActionCreators(actions, store.dispatch);
-    let data = selector(store.getState());
-    assert(
-      data && typeof data === 'object',
-      '"selector" must return an object. Please provide a valid selector.\n' +
-        `Selector given: ${selector}\n` +
-        `Value returned: ${data}`
-    );
-
-    this.store = store;
-    Object.keys(boundActions).forEach((actionName) => {
-      this[actionName] = function(...args) {
-        if(window.Event && window.Event.prototype.isPrototypeOf(args[0])) {
-          args[0].preventUpdate = true;
-        }
-        return boundActions[actionName](...args);
-      };
-    });
-    Object.keys(data).forEach((key) => this[key] = data[key]);
-
-    subscribe.call(this, selector);
+    let data = getState()
+    let unsubscribe = store.subscribe(subscribe);
+    this.on("unmount", ()=> unsubscribe())
+    subscribe();
   }
 
   return {init};


### PR DESCRIPTION
1. uses `this.state`, `this.actions` to access state and actions
2. support creating mixin with selector and actions, so there's an option that no need for a provider tag.
3. much smaller codebase

like this: 

tiger.tag

``` html
<tiger>
  <p>{stateage}</p> <!-- 12 -->
  <button onclick={actions.roar}></button> <!-- Clicking me prints 'BWAAA!' in the console. -->
  <script>
    const store = configureStore({age:12});
    let actions = {roar: () => console.log('BWAAA!')};
    let selector = (state) => ({age: state.age});
    let riotRedux = require("riot-redux").default
    this.mixin(riotRedux(
      store, selector, actions
    ));
  </script>
</tiger>
```
